### PR TITLE
Fix GitHub Pages deployment branch error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -35,18 +33,8 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
Changed from artifact-based deployment (deploy-pages@v4) to gh-pages branch deployment using peaceiris/actions-gh-pages@v3. This resolves the deployment error where the repository settings require deployment from the gh-pages branch.

Changes:
- Removed upload-pages-artifact and deploy-pages steps
- Combined build and deploy into a single job
- Updated permissions from pages/id-token to contents write
- Using peaceiris/actions-gh-pages to deploy dist folder to gh-pages